### PR TITLE
Build config and signals

### DIFF
--- a/build-scripts/cmake/CMakeLists.txt
+++ b/build-scripts/cmake/CMakeLists.txt
@@ -20,6 +20,10 @@ option(
   ISCOOL_CORE_WITH_CMAKE_PACKAGE
   "Generate and install cmake package files" OFF
   )
+option(
+  ISCOOL_AUTO_RUN_TESTS
+  "Run the unit tests during the build." ON
+  )
 
 if( ISCOOL_CORE_WITH_CMAKE_PACKAGE )
   set( iscool_core_export EXPORT iscool-core )

--- a/build-scripts/cmake/cmake-modules/declare-iscool-library-test.cmake
+++ b/build-scripts/cmake/cmake-modules/declare-iscool-library-test.cmake
@@ -49,9 +49,11 @@ function( declare_iscool_library_test )
     ${google_test_LIBRARIES}
     )
 
-  add_custom_command( TARGET ${executable_name}
-    POST_BUILD
-    COMMAND ${executable_name}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
+  if( ISCOOL_AUTO_RUN_TESTS )
+    add_custom_command( TARGET ${executable_name}
+      POST_BUILD
+      COMMAND ${executable_name}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      )
+  endif()
 endfunction()

--- a/build-scripts/cmake/cmake-modules/jsoncpp.cmake
+++ b/build-scripts/cmake/cmake-modules/jsoncpp.cmake
@@ -9,7 +9,7 @@ include( install-dependency )
 download_project(
   PROJ jsoncpp
   GIT_REPOSITORY https://github.com/open-source-parsers/jsoncpp.git
-  GIT_TAG master
+  GIT_TAG 1.8.4
   UPDATE_DISCONNECTED 1
   )
 

--- a/build-scripts/cmake/cmake-modules/unity-build.cmake
+++ b/build-scripts/cmake/cmake-modules/unity-build.cmake
@@ -1,7 +1,19 @@
 include( platform )
 
+option(
+  ENABLE_COMPILATION_UNITS
+  "Merge all source files together to reduce the number of times the compiler\
+ is invoked."
+  ON
+  )
+
 function( make_compilation_unit unit_file name )
 
+  if(NOT ENABLE_COMPILATION_UNITS)
+    set( ${unit_file} ${ARGN} PARENT_SCOPE )
+    return()
+  endif()
+  
   set( temporary_unit "${PROJECT_BINARY_DIR}/${name}.unit.tmp" )
   file( REMOVE "${temporary_unit}" )
 

--- a/modules/core/collections/module/include/iscool/collections/detail/rank.tpp
+++ b/modules/core/collections/module/include/iscool/collections/detail/rank.tpp
@@ -16,6 +16,8 @@
 #ifndef ISCOOL_COLLECTIONS_RANK_TPP
 #define ISCOOL_COLLECTIONS_RANK_TPP
 
+#include <cstdlib>
+
 template< typename Iterator, typename Output >
 void iscool::collections::rank
 ( Iterator value_first, Iterator value_last, Output&& output )

--- a/modules/core/files/module/src/iscool/files/file_exists.cpp
+++ b/modules/core/files/module/src/iscool/files/file_exists.cpp
@@ -17,6 +17,8 @@
 
 #include "iscool/files/detail/system_delegates.h"
 
+#include <cassert>
+
 bool iscool::files::file_exists( const std::string& path )
 {
     assert( detail::system_delegates != nullptr );

--- a/modules/core/files/module/src/iscool/files/get_full_path.cpp
+++ b/modules/core/files/module/src/iscool/files/get_full_path.cpp
@@ -17,6 +17,8 @@
 
 #include "iscool/files/detail/system_delegates.h"
 
+#include <cassert>
+
 std::string iscool::files::get_full_path( const std::string& path )
 {
     assert( detail::system_delegates != nullptr );

--- a/modules/core/files/module/src/iscool/files/get_writable_path.cpp
+++ b/modules/core/files/module/src/iscool/files/get_writable_path.cpp
@@ -17,6 +17,8 @@
 
 #include "iscool/files/detail/system_delegates.h"
 
+#include <cassert>
+
 std::string iscool::files::get_writable_path()
 {
     assert( detail::system_delegates != nullptr );

--- a/modules/core/files/module/src/iscool/files/read_file.cpp
+++ b/modules/core/files/module/src/iscool/files/read_file.cpp
@@ -17,6 +17,8 @@
 
 #include "iscool/files/detail/system_delegates.h"
 
+#include <cassert>
+
 std::unique_ptr< std::istream >
 iscool::files::read_file( const std::string& path )
 {

--- a/modules/core/files/module/src/iscool/files/setup.cpp
+++ b/modules/core/files/module/src/iscool/files/setup.cpp
@@ -17,6 +17,8 @@
 
 #include "iscool/files/detail/system_delegates.h"
 
+#include <cassert>
+
 void iscool::files::initialize( const file_system_delegates& delegates )
 {
     assert( detail::system_delegates == nullptr );

--- a/modules/core/json/tests/src/iscool/json/write_to_stream.cpp
+++ b/modules/core/json/tests/src/iscool/json/write_to_stream.cpp
@@ -17,6 +17,7 @@
 
 #include "iscool/json/cast_int.h"
 #include "iscool/json/cast_string.h"
+#include "iscool/json/parse_stream.h"
 
 #include <gtest/gtest.h>
 

--- a/modules/core/log/module/src/iscool/log/setup.cpp
+++ b/modules/core/log/module/src/iscool/log/setup.cpp
@@ -16,6 +16,7 @@
 #include "iscool/log/setup.h"
 
 #include "iscool/log/detail/get_message_dispatcher.h"
+#include "iscool/log/detail/logger_thread.h"
 #include "iscool/log/detail/message_dispatcher.h"
 
 #ifndef NDEBUG

--- a/modules/core/net/module/include/iscool/net/byte_array_bit_reader.h
+++ b/modules/core/net/module/include/iscool/net/byte_array_bit_reader.h
@@ -16,6 +16,8 @@
 #ifndef ISCOOL_NET_BYTE_ARRAY_BIT_READER_H
 #define ISCOOL_NET_BYTE_ARRAY_BIT_READER_H
 
+#include <cstdint>
+
 namespace iscool
 {
     namespace net

--- a/modules/core/net/module/src/iscool/net/socket_stream.cpp
+++ b/modules/core/net/module/src/iscool/net/socket_stream.cpp
@@ -18,6 +18,8 @@
 #include "iscool/schedule/delayed_call.h"
 #include "iscool/signals/implement_signal.h"
 
+#include <boost/bind.hpp>
+
 IMPLEMENT_SIGNAL( iscool::net::socket_stream, received, _received );
 
 iscool::net::socket_stream::socket_stream( const std::string& host )

--- a/modules/core/preferences/module/src/iscool/preferences/declare_global_int64_property.cpp
+++ b/modules/core/preferences/module/src/iscool/preferences/declare_global_int64_property.cpp
@@ -15,6 +15,8 @@
 */
 #include "iscool/preferences/declare_global_int64_property.h"
 
+#include "iscool/preferences/detail/property.impl.tpp"
+
 iscool::preferences::int64_property
 iscool::preferences::declare_global_int64_property
 ( std::string&& name, std::int64_t fallback )

--- a/modules/core/preferences/module/src/iscool/preferences/store.cpp
+++ b/modules/core/preferences/module/src/iscool/preferences/store.cpp
@@ -15,6 +15,7 @@
 */
 #include "iscool/preferences/store.h"
 
+#include "iscool/preferences/property_map.impl.h"
 #include "iscool/schedule/delayed_call.h"
 
 #include <boost/bind.hpp>

--- a/modules/core/preferences/tests/src/iscool/preferences/local_preferences.cpp
+++ b/modules/core/preferences/tests/src/iscool/preferences/local_preferences.cpp
@@ -15,6 +15,7 @@
 */
 #include "iscool/preferences/local_preferences.h"
 
+#include "iscool/preferences/property_map.impl.h"
 #include "iscool/schedule/manual_scheduler.h"
 #include "iscool/schedule/setup.h"
 

--- a/modules/core/preferences/tests/src/iscool/preferences/property_deserializer.cpp
+++ b/modules/core/preferences/tests/src/iscool/preferences/property_deserializer.cpp
@@ -15,6 +15,8 @@
 */
 #include "iscool/preferences/property_deserializer.h"
 
+#include "iscool/preferences/property_map.impl.h"
+
 #include "iscool/test/debug_crash.h"
 
 #include <algorithm>

--- a/modules/core/schedule/module/include/iscool/schedule/detail/clock.tpp
+++ b/modules/core/schedule/module/include/iscool/schedule/detail/clock.tpp
@@ -16,6 +16,8 @@
 #ifndef ISCOOL_SCHEDULE_CLOCK_TPP
 #define ISCOOL_SCHEDULE_CLOCK_TPP
 
+#include "iscool/signals/signal.impl.tpp"
+
 template<typename Tick>
 iscool::signals::connection
 iscool::schedule::clock< Tick >::connect_to_tick

--- a/modules/core/schedule/tests/src/iscool/schedule/task_group.cpp
+++ b/modules/core/schedule/tests/src/iscool/schedule/task_group.cpp
@@ -18,6 +18,7 @@
 #include "iscool/schedule/setup.h"
 #include "iscool/schedule/task_group.h"
 #include "iscool/schedule/task_group.impl.tpp"
+#include "iscool/signals/signal.impl.tpp"
 
 #include <thread>
 

--- a/modules/core/schedule/tests/src/iscool/schedule/worker.cpp
+++ b/modules/core/schedule/tests/src/iscool/schedule/worker.cpp
@@ -18,6 +18,7 @@
 #include "iscool/schedule/delayed_call.h"
 #include "iscool/schedule/manual_scheduler.h"
 #include "iscool/schedule/setup.h"
+#include "iscool/signals/signal.impl.tpp"
 
 #include "iscool/test/no_crash.h"
 

--- a/modules/core/schedule/tests/src/iscool/schedule/worker.cpp
+++ b/modules/core/schedule/tests/src/iscool/schedule/worker.cpp
@@ -21,6 +21,7 @@
 
 #include "iscool/test/no_crash.h"
 
+#include <thread>
 #include <unistd.h>
 
 #include "iscool/schedule/test/observable_task.h"

--- a/modules/core/signals/module/include/iscool/signals/detail/signal.impl.tpp
+++ b/modules/core/signals/module/include/iscool/signals/detail/signal.impl.tpp
@@ -103,7 +103,7 @@ iscool::signals::detail::signal< Signature >::operator()( Arg&&... arg ) const
 
         for( const auto& s : slots )
             if ( s->connected() )
-                s->callback( std::forward< Arg >( arg )... );
+                s->callback( arg... );
     }
 }
 

--- a/modules/core/signals/tests/src/iscool/signals/connection.cpp
+++ b/modules/core/signals/tests/src/iscool/signals/connection.cpp
@@ -15,6 +15,8 @@
 */
 #include "iscool/signals/signal.h"
 
+#include "iscool/signals/signal.impl.tpp"
+
 #include <gtest/gtest.h>
 
 TEST( iscool_signals_connection, initially_disconnected )

--- a/modules/core/signals/tests/src/iscool/signals/scoped_connection.cpp
+++ b/modules/core/signals/tests/src/iscool/signals/scoped_connection.cpp
@@ -14,7 +14,9 @@
   limitations under the License.
 */
 #include "iscool/signals/signal.h"
+
 #include "iscool/signals/scoped_connection.h"
+#include "iscool/signals/signal.impl.tpp"
 
 #include <gtest/gtest.h>
 

--- a/modules/core/style/module/include/iscool/style/detail/merge_declarations.h
+++ b/modules/core/style/module/include/iscool/style/detail/merge_declarations.h
@@ -18,6 +18,8 @@
 
 #include "iscool/style/declaration.h"
 
+#include <vector>
+
 namespace iscool
 {
     namespace style

--- a/modules/core/style/module/src/iscool/style/detail/set_property_from_json_value.cpp
+++ b/modules/core/style/module/src/iscool/style/detail/set_property_from_json_value.cpp
@@ -31,6 +31,8 @@
 #include "iscool/log/causeless_log.h"
 #include "iscool/log/nature/info.h"
 
+#include <json/value.h>
+
 #include <boost/algorithm/string.hpp>
 
 namespace iscool

--- a/modules/core/style/tests/src/iscool/style/json/to_declaration.cpp
+++ b/modules/core/style/tests/src/iscool/style/json/to_declaration.cpp
@@ -13,11 +13,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-#include "gtest/gtest.h"
-
 #include "iscool/style/json/to_declaration.h"
 
 #include "iscool/json/parse_string.h"
+#include "iscool/optional.impl.tpp"
+
+#include "gtest/gtest.h"
 
 class iscool_style_declaration_json_test:
     public ::testing::Test

--- a/modules/core/system/module/src/iscool/system/detail/haptic_feedback_mockup.cpp
+++ b/modules/core/system/module/src/iscool/system/detail/haptic_feedback_mockup.cpp
@@ -19,6 +19,7 @@
 #include "iscool/system/haptic_feedback_notification.h"
 
 #include <cassert>
+#include <string>
 
 bool iscool::system::haptic_feedback::is_available() const
 {


### PR DESCRIPTION
Please merge these commits to

- add options to disable the unity build,
- add missing include directives,
- fix how the arguments are passed to the callbacks when multiple callbacks are connected to a signal,
- set the version of JsonCpp to a known compatible version.